### PR TITLE
Fix documentation build: avoid wrapping headings

### DIFF
--- a/docs/scripts/build_examples.py
+++ b/docs/scripts/build_examples.py
@@ -158,7 +158,11 @@ def build_examples(destination_directory: Path, dummy: bool, remove_dir: bool):
                         continue
                     if any(substring in line for substring in ignored_substrings):
                         continue
-                    if len(line) > 88 and "](" not in line:
+                    if (
+                        len(line) > 88
+                        and "](" not in line
+                        and not line.lstrip().startswith("#")
+                    ):
                         wrapped = textwrap.wrap(line, width=88)
                         wrapped_lines.extend(wrapped)
                     else:


### PR DESCRIPTION
The documentation build script `docs/scripts/build_examples.py` wraps long lines in example files. This caused an issue where long headings (starting with `#`) were split, resulting in broken formatting (e.g., the second part of the heading being rendered as normal text).

This change adds a check to ensure that lines starting with `#` are not wrapped, preserving the integrity of headings.

Tested with a reproduction script `reproduce_issue.py` which confirmed that the fix correctly preserves headings while still wrapping other long lines. `tox -e lint` passed.

---
*PR created automatically by Jules for task [12038697284288887799](https://jules.google.com/task/12038697284288887799) started by @Scienfitz*